### PR TITLE
[ENH] Add compatibility between fully synthetic and ADNI-based synthetic data

### DIFF
--- a/notebooks_py/model_fits_synthetic.py
+++ b/notebooks_py/model_fits_synthetic.py
@@ -59,7 +59,7 @@ try:
 except FileNotFoundError:
     print("Results not available")
 
-n_biomarkers = json_data["settings"]["n_biomarkers"]
+n_biomarkers = len(json_data["cols"]["cols_biomarker"])
 
 params = json_data["params"]
 k_values = np.array(params["k_values"])
@@ -70,7 +70,10 @@ time_shifts = np.concatenate(params["time_shifts"])
 acceleration_factors = np.concatenate(params["acceleration_factors"])
 sigmas = params["sigmas"]
 
-n_sites = len(json_data["settings"]["n_subjects_all"])
+col_subject = json_data["cols"]["col_subject"]
+
+# number of sites minus the centralized site
+n_sites = len(json_data["subjects_by_node"]) - 1
 
 df = pd.concat(
     {
@@ -104,7 +107,7 @@ def save_fig(fig: sns.FacetGrid | plt.Figure, fname, extension="svg", **kwargs):
 
 # vertical
 fig_data, axes = plt.subplots(
-    nrows=2, figsize={"paper": (2.5, 4), "talk": (4, 8)}[THEME]
+    nrows=3, figsize={"paper": (2.5, 6), "talk": (4, 12)}[THEME]
 )
 
 
@@ -112,7 +115,7 @@ for i_ax, ax in enumerate(axes):
     ax: plt.Axes
 
     n_subjects_per_site = {}
-    for i_subject, (subject, df_subject) in enumerate(df.groupby("subject")):
+    for i_subject, (subject, df_subject) in enumerate(df.groupby(col_subject)):
         site = df_subject["site"].unique().item()
         if site not in n_subjects_per_site:
             n_subjects_per_site[site] = 0
@@ -120,17 +123,17 @@ for i_ax, ax in enumerate(axes):
         if n_subjects_per_site[site] >= N_SUBJECTS:
             continue
 
+        timepoints = df_subject[json_data["cols"]["col_timepoint"]]
+        if i_ax == 0:
+            timepoints = (timepoints + time_shifts[i_subject]) * acceleration_factors[
+                i_subject
+            ]
+        elif i_ax == 1:
+            timepoints = timepoints * acceleration_factors[i_subject]
+
         for i_biomarker, biomarker in enumerate(json_data["cols"]["cols_biomarker"]):
             ax.plot(
-                (
-                    (
-                        df_subject[json_data["cols"]["col_timepoint"]]
-                        + time_shifts[i_subject]
-                    )
-                    * acceleration_factors[i_subject]
-                    if i_ax == 0
-                    else df_subject[json_data["cols"]["col_timepoint"]]
-                ),
+                timepoints,
                 df_subject[biomarker],
                 marker="oXxp*"[site - 1],
                 color=f"C{i_biomarker}",
@@ -150,7 +153,8 @@ for i_ax, ax in enumerate(axes):
     ax.set_ylabel(BIOMARKER_LABEL)
 
 axes[0].set_title("Before time shift and acceleration")
-axes[1].set_title("After time shift and acceleration")
+axes[1].set_title("After time shift")
+axes[2].set_title("After time shift and acceleration")
 fig_data.tight_layout()
 
 XLIM = axes[0].get_xlim()
@@ -278,94 +282,3 @@ for ax, setup in zip(axes.flatten(), results_dict["results"].keys()):
     ax.set_title(setup.capitalize())
 
 fig_model_fit.tight_layout()
-
-# %%
-save_fig(fig_model_fit, f"{TAG}-model_fit-{THEME}", extension="svg")
-
-# %%
-N_SUBJECTS_FITS = 2
-
-# vertical
-fig_fit_data, axes = plt.subplots(ncols=3, figsize=(8, 2))
-
-for i_ax, ax in enumerate(axes):
-    ax: plt.Axes
-
-    match i_ax:
-        case 0:
-            time_shifts_to_plot = time_shifts
-            acceleration_factors_to_plot = acceleration_factors
-        case 1:
-            time_shifts_to_plot = np.hstack(
-                list(
-                    results_dict["results"]["centralized"][
-                        "estimated_time_shifts"
-                    ].values()
-                )
-            )
-            acceleration_factors_to_plot = np.hstack(
-                list(
-                    results_dict["results"]["centralized"][
-                        "estimated_acceleration_factors"
-                    ].values()
-                )
-            )
-        case 2:
-            time_shifts_to_plot = np.hstack(
-                list(
-                    results_dict["results"]["federated"][
-                        "estimated_time_shifts"
-                    ].values()
-                )
-            )
-            acceleration_factors_to_plot = np.hstack(
-                list(
-                    results_dict["results"]["federated"][
-                        "estimated_acceleration_factors"
-                    ].values()
-                )
-            )
-
-    n_subjects = 0
-    for i_subject, (subject, df_subject) in enumerate(df.groupby("subject")):
-        site = df_subject["site"].unique().item()
-
-        if n_subjects >= N_SUBJECTS_FITS:
-            continue
-
-        print(subject)
-
-        for i_biomarker, biomarker in enumerate(json_data["cols"]["cols_biomarker"]):
-            ax.plot(
-                (
-                    (
-                        df_subject[json_data["cols"]["col_timepoint"]]
-                        + time_shifts_to_plot[i_subject]
-                    )
-                    * acceleration_factors_to_plot[i_subject]
-                ),
-                df_subject[biomarker],
-                marker="oXxp*"[site - 1],
-                color=f"C{i_biomarker}",
-                # alpha=0.1,
-                alpha=0.2,
-            )
-        n_subjects += 1
-
-    for i_biomarker, (k, x0, vertical_shift, scaling_factor) in enumerate(
-        zip(k_values, x0_values, vertical_shifts, scaling_factors)
-    ):
-        t = np.linspace(-0.5, 1.5, 100)
-        y = 1 / (1 + np.exp(-k * (t - x0))) * scaling_factor + vertical_shift
-        ax.plot(t, y, color=f"C{i_biomarker}", linestyle="--", alpha=1)
-
-    ax.set_xlabel(TIME_LABEL)
-    ax.set_ylabel(BIOMARKER_LABEL)
-
-axes[0].set_title("Ground truth")
-axes[1].set_title("Centralized")
-axes[2].set_title("Federated")
-fig_fit_data.tight_layout()
-
-for ax in axes:
-    ax.set_xlim(-0, 0.5)

--- a/scripts/get_adni_data.py
+++ b/scripts/get_adni_data.py
@@ -3,6 +3,7 @@
 import enum
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Any
 
 import click
 import numpy as np
@@ -174,6 +175,57 @@ def _add_adni_age_column(
     return df.set_index(index_names)
 
 
+def _build_params_from_simulation(
+    simulation_metadata: dict[str, Any],
+    cols_biomarker: list[str],
+    subjects_by_node: dict[str, list[str]],
+) -> dict[str, Any]:
+    """Build a ground-truth parameter set from the simulation metadata."""
+    params = simulation_metadata["params"]
+
+    if sorted(cols_biomarker) != sorted(simulation_metadata["measures"]):
+        raise ValueError(
+            "cols_biomarker must match the simulated measures when "
+            "--simulation-metadata is provided. Got "
+            f"{sorted(cols_biomarker)}, expected "
+            f"{sorted(simulation_metadata['measures'])}."
+        )
+
+    shift_by_rid = {
+        _normalize_adni_rid(rid): float(shift)
+        for rid, shift in params["time_shifts"].items()
+    }
+    acceleration_by_rid = {
+        _normalize_adni_rid(rid): float(acceleration)
+        for rid, acceleration in params["acceleration_factors"].items()
+    }
+
+    time_shifts = []
+    acceleration_factors = []
+    for participant_ids in subjects_by_node.values():
+        normalized_rids = [_normalize_adni_rid(rid) for rid in participant_ids]
+        missing_rids = sorted(set(normalized_rids) - set(shift_by_rid))
+        if missing_rids:
+            raise ValueError(
+                "Simulation metadata is missing time shifts for RIDs: "
+                f"{missing_rids[:10]}"
+            )
+        time_shifts.append([shift_by_rid[rid] for rid in normalized_rids])
+        acceleration_factors.append(
+            [acceleration_by_rid[rid] for rid in normalized_rids]
+        )
+
+    return {
+        "time_shifts": time_shifts,
+        "acceleration_factors": acceleration_factors,
+        "k_values": params["k_values"],
+        "x0_values": params["x0_values"],
+        "vertical_shifts": params["vertical_shifts"],
+        "scaling_factors": params["scaling_factors"],
+        "sigmas": params["sigmas"],
+    }
+
+
 def get_adni_data(
     tag: str,
     fpath_idps: Path,
@@ -184,11 +236,17 @@ def get_adni_data(
     iid: bool = DEFAULT_IID,
     rng_seed: int | None = None,
     non_iid_strategy: str = DEFAULT_NON_IID_STRATEGY,
+    simulation_metadata: Path | None = None,
 ):
     dpath_out = get_dpath_latest(dpath_data, use_today=True) / tag
     dpath_out.mkdir(parents=True, exist_ok=True)
 
     config = load_json(fpath_config)
+
+    if simulation_metadata is not None:
+        sim_metadata = load_json(simulation_metadata)
+    else:
+        sim_metadata = None
 
     json_data = {"settings": locals().copy()}
 
@@ -332,6 +390,13 @@ def get_adni_data(
 
     json_data["subjects_by_node"] = subjects_by_node
 
+    if sim_metadata is not None:
+        json_data["params"] = _build_params_from_simulation(
+            simulation_metadata=sim_metadata,
+            cols_biomarker=sorted(cols_biomarkers),
+            subjects_by_node=subjects_by_node,
+        )
+
     fpath_json = dpath_out / _get_fname_out(tag, suffix=".json")
     save_json(fpath_json, json_data)
     print(f"Saved settings, col names, and node ID map to {fpath_json}")
@@ -372,6 +437,12 @@ def get_adni_data(
     "--non-iid-strategy",
     type=click.Choice(NonIIDStrategy, case_sensitive=False),
     default=DEFAULT_NON_IID_STRATEGY,
+)
+@click.option(
+    "--simulation-metadata",
+    type=click.Path(path_type=Path, file_okay=True, dir_okay=False),
+    default=None,
+    help="Path to the metadata JSON file. Specify when simulated ADNI data is used.",
 )
 def main(*args, **kwargs):
     get_adni_data(*args, **kwargs)

--- a/scripts/simulate_data_adni_timeshift.py
+++ b/scripts/simulate_data_adni_timeshift.py
@@ -870,6 +870,62 @@ def _calibration_to_json(calibration: Calibration) -> dict[str, Any]:
     return _json_ready(data)
 
 
+def _build_mirrored_params(
+    calibration: Calibration,
+    config: dict[str, Any],
+    df_fs_sim: pd.DataFrame,
+) -> dict[str, Any]:
+    """Build a simulate_data.py-style ``params`` entry in model space.
+
+    Time is scaled by ``config['max_time']`` (months -> model time units),
+    matching the transform applied by get_adni_data.py. Per-biomarker arrays
+    follow sorted-measure order; time shifts and acceleration factors are
+    keyed by normalized RID. vertical_shifts and scaling_factors are fixed to
+    the model's parametrization (0 and 1). sigmas are the generative noise
+    standard deviations rescaled to the min-max-normalized observation space.
+    """
+    t_unit = config.get("max_time") or 1.0
+
+    time_shifts_months = (
+        df_fs_sim.groupby(FS_COL_SUBJECT)[COL_TRUE_TIME_SHIFT].first().astype(float)
+    )
+
+    params: dict[str, Any] = {
+        "time_shifts": {
+            str(rid): float(shift_months / t_unit)
+            for rid, shift_months in time_shifts_months.items()
+        },
+        "acceleration_factors": {str(rid): 1.0 for rid in time_shifts_months.index},
+        "k_values": [],
+        "x0_values": [],
+        "vertical_shifts": [],
+        "scaling_factors": [],
+        "sigmas": [],
+    }
+
+    min_max_by_measure = config.get("min_max_by_measure", {})
+
+    for measure in sorted(calibration.biomarkers):
+        biomarker = calibration.biomarkers[measure]
+
+        if measure not in min_max_by_measure:
+            raise ValueError(
+                f"config['min_max_by_measure'] is missing an entry for "
+                f"{measure!r}, which is required to express sigmas in model space."
+            )
+
+        value_min, value_max = min_max_by_measure[measure]
+        value_range = abs(value_max - value_min)
+
+        params["k_values"].append(biomarker.slope * t_unit / 12.0)
+        params["x0_values"].append(biomarker.midpoint * 12.0 / t_unit)
+        params["vertical_shifts"].append(0.0)
+        params["scaling_factors"].append(1.0)
+        params["sigmas"].append(biomarker.noise_sd / value_range)
+
+    return params
+
+
 def simulate_data_adni_timeshift(
     tag: str,
     dpath_data: Path,
@@ -913,13 +969,19 @@ def simulate_data_adni_timeshift(
     fpath_fs_out = dpath_out / Path(freesurfer_csv).name
     fpath_merge_out = dpath_out / Path(adni_merge_csv).name
     fpath_config_out = dpath_out / Path(config).name
-    fpath_metadata_out = dpath_out / f"{tag}_simulation_metadata.json"
+    fpath_metadata_out = dpath_out / "simulation_metadata.json"
 
     df_fs_sim.to_csv(fpath_fs_out, index=False)
     df_merge_sim.to_csv(fpath_merge_out, index=False)
 
     # Keep config unchanged so get_adni_data.py sees the same measure list.
     save_json(fpath_config_out, config_data)
+
+    mirrored_params = _build_mirrored_params(
+        calibration=calibration,
+        config=config_data,
+        df_fs_sim=df_fs_sim,
+    )
 
     metadata = {
         "description": (
@@ -942,6 +1004,7 @@ def simulate_data_adni_timeshift(
             COL_TRUE_DISEASE_STAGE,
             COL_TRUE_TIME_SHIFT,
         ],
+        "params": mirrored_params,
         "calibration": _calibration_to_json(calibration),
     }
     save_json(fpath_metadata_out, metadata)


### PR DESCRIPTION
@kinichen this is my attempt at extracting the ground truth params from your `scripts/simulate_data_adni_timeshift.py` script in a way that is compatible with the output of `scripts/simulate_data.py`, so that downstream scripts/notebooks (e.g. metrics extraction script #16) are fully compatible with both kinds of simulated data. Could you take a look and see if this is correct?